### PR TITLE
Fix typo in manual

### DIFF
--- a/src/manual.tsx
+++ b/src/manual.tsx
@@ -73,7 +73,7 @@ export default function Manual() {
 
       <Flex as="section" direction="column" gap="8px">
         <Heading as="h3">
-          Request & Reoprt
+          Request & Report
         </Heading>
         <Box>
           <Text as="p">


### PR DESCRIPTION
<img width="630" alt="スクリーンショット 2023-03-30 16 59 18" src="https://user-images.githubusercontent.com/42153744/228769607-b62ade21-2792-441c-8d41-8847323f4c59.png">

↓

<img width="588" alt="スクリーンショット 2023-03-30 16 59 49" src="https://user-images.githubusercontent.com/42153744/228769742-2745c97c-5e3d-487a-b35c-85e4c73c826c.png">
