### PR TITLE
Support Text Preview

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -17,7 +17,6 @@ import SelectPHP from './select';
 import { Editor } from './editor';
 import { SunIcon } from '@chakra-ui/icons';
 import {Format, SelectFormat} from "./format";
-import {c} from "../public/index-b4fe954f";
 
 type UrlState = {
 	v: Version;

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -151,6 +151,7 @@ export default function App() {
 			<Editor
 				initCode={initCode}
 				version={currentVersion}
+				format={currentFormat}
 				onChangeCode={function (code: string) {
 					setHistory(code, currentVersion, currentFormat);
 				}}

--- a/src/editor.tsx
+++ b/src/editor.tsx
@@ -10,6 +10,7 @@ import { Box, Center, Flex, Spinner } from '@chakra-ui/react';
 import type { ReactElement } from 'react';
 import * as React from 'react';
 import MonacoEditor from '@monaco-editor/react';
+import {Format} from "./format";
 
 function LoadSpinner() {
 	return (
@@ -41,7 +42,7 @@ function PhpEditor() {
 	);
 }
 
-function PhpPreview(params: { version: Version }) {
+function PhpPreview(params: { version: Version, format: Format }) {
 	const { sandpack } = useSandpack();
 	const { files, activeFile } = sandpack;
 	const code = files[activeFile].code;
@@ -50,8 +51,12 @@ function PhpPreview(params: { version: Version }) {
 	if (loading) {
 		return <LoadSpinner />;
 	}
+	let render = result;
+	if (params.format === "console") {
+		render = `<pre>${result}</pre>`;
+	}
 
-	return <iframe srcDoc={result} height="100%" width="100%" sandbox="" />;
+	return <iframe srcDoc={render} height="100%" width="100%" sandbox="" />;
 }
 
 function PhpCodeCallback(params: { onChangeCode: (code: string) => void }) {
@@ -106,6 +111,7 @@ function EditorLayout(params: { Editor: ReactElement; Preview: ReactElement }) {
 export function Editor(params: {
 	initCode: string;
 	version: Version;
+	format: Format;
 	onChangeCode: (code: string) => void;
 }) {
 	return (
@@ -119,7 +125,7 @@ export function Editor(params: {
 		>
 			<EditorLayout
 				Editor={<PhpEditor />}
-				Preview={<PhpPreview version={params.version} />}
+				Preview={<PhpPreview version={params.version} format={params.format} />}
 			/>
 			<PhpCodeCallback onChangeCode={params.onChangeCode} />
 		</SandpackProvider>

--- a/src/editor.tsx
+++ b/src/editor.tsx
@@ -51,12 +51,11 @@ function PhpPreview(params: { version: Version, format: Format }) {
 	if (loading) {
 		return <LoadSpinner />;
 	}
-	let render = result;
 	if (params.format === "console") {
-		render = `<pre>${result}</pre>`;
+		return <pre style={{textWrap: "wrap"}}>{result}</pre>;
 	}
 
-	return <iframe srcDoc={render} height="100%" width="100%" sandbox="" />;
+	return <iframe srcDoc={result} height="100%" width="100%" sandbox="" />;
 }
 
 function PhpCodeCallback(params: { onChangeCode: (code: string) => void }) {

--- a/src/editor.tsx
+++ b/src/editor.tsx
@@ -52,7 +52,7 @@ function PhpPreview(params: { version: Version, format: Format }) {
 		return <LoadSpinner />;
 	}
 	if (params.format === "console") {
-		return <pre style={{textWrap: "wrap"}}>{result}</pre>;
+		return <pre style={{whiteSpace: "pre-wrap", overflow: "scroll", width: "100%", height: "100%"}}>{result}</pre>;
 	}
 
 	return <iframe srcDoc={result} height="100%" width="100%" sandbox="" />;
@@ -80,7 +80,7 @@ function EditorLayout(params: { Editor: ReactElement; Preview: ReactElement }) {
 					as={SandpackLayout}
 					flexDirection={{ base: 'column', lg: 'row' }}
 					height={{ base: '50%', lg: '100%' }}
-					width="100%"
+					width={{ base: '100%', lg: '50%' }}
 				>
 					<Box
 						as="span"
@@ -94,8 +94,8 @@ function EditorLayout(params: { Editor: ReactElement; Preview: ReactElement }) {
 					</Box>
 				</Box>
 				<Box
-					width="100%"
 					height={{ base: '50%', lg: '100%' }}
+					width={{ base: '100%', lg: '50%' }}
 					style={{
 						backgroundColor: 'white',
 					}}

--- a/src/format.tsx
+++ b/src/format.tsx
@@ -1,4 +1,5 @@
-import {Version} from "./php-wasm/php";
+import {Checkbox} from "@chakra-ui/react";
+import {useState} from "react";
 
 export type Format = "html" | "console";
 
@@ -6,11 +7,20 @@ export type Format = "html" | "console";
 export function SelectFormat(
     {
         format,
-        onChange,
+        updateFormat,
     }: {
         format: Format;
         updateFormat: (f: Format) => void;
     }
 ) {
-    return format
+    const [isHtml, setIsHtml] = useState<boolean>(format === "html");
+
+    return <Checkbox
+        isChecked={isHtml}
+        onChange={(e) => {
+            updateFormat(e.target.checked ? "html" : "console");
+            setIsHtml(e.target.checked);
+        }}>
+        HTML display
+    </Checkbox>
 }

--- a/src/format.tsx
+++ b/src/format.tsx
@@ -1,0 +1,16 @@
+import {Version} from "./php-wasm/php";
+
+export type Format = "html" | "console";
+
+
+export function SelectFormat(
+    {
+        format,
+        onChange,
+    }: {
+        format: Format;
+        updateFormat: (f: Format) => void;
+    }
+) {
+    return format
+}

--- a/src/format.tsx
+++ b/src/format.tsx
@@ -1,4 +1,5 @@
 import {Checkbox} from "@chakra-ui/react";
+import * as React from 'react';
 import {useState} from "react";
 
 export type Format = "html" | "console";

--- a/src/format.tsx
+++ b/src/format.tsx
@@ -21,6 +21,6 @@ export function SelectFormat(
             updateFormat(e.target.checked ? "html" : "console");
             setIsHtml(e.target.checked);
         }}>
-        HTML display
+        HTML Preview
     </Checkbox>
 }


### PR DESCRIPTION
fix: https://github.com/glassmonkey/php-playground/issues/89



# detail

Add Checkbox of choising preview style.
default: HTML Preview

##  Conventional preview (HTML Preview)
<img width="1442" alt="スクリーンショット 2023-11-12 21 10 08" src="https://github.com/glassmonkey/php-playground/assets/7159100/a4d90b32-7761-4da8-b3df-8d3fbccf0ad1">


##  New preview (Text Preview)
<img width="1447" alt="スクリーンショット 2023-11-12 21 10 22" src="https://github.com/glassmonkey/php-playground/assets/7159100/72aa60bc-8368-47f5-a3b7-45ab21888c8f">