### PR TITLE
fix: parallel run

### DIFF
--- a/e2e/e2e.spec.ts
+++ b/e2e/e2e.spec.ts
@@ -17,7 +17,9 @@ test.describe('default page', () => {
   })
 
   test('default URL', async ({ page }) => {
-    expect(page.url()).toBe('http://127.0.0.1:18888/?c=DwfgDgFmBQD0sAICmAPAhgWzAGyQgxgPYAmS0kYAlgHYBmhAFAJQDcQA&v=8.3&f=html')
+    expect(page.url()).toContain('c=DwfgDgFmBQD0sAICmAPAhgWzAGyQgxgPYAmS0kYAlgHYBmhAFAJQDcQA')
+    expect(page.url()).toContain('v=8.3')
+    expect(page.url()).toContain('f=html')
   })
 
   test('switch preview', async ({ page }) => {

--- a/e2e/e2e.spec.ts
+++ b/e2e/e2e.spec.ts
@@ -17,9 +17,9 @@ test.describe('default page', () => {
   })
 
   test('default URL', async ({ page }) => {
-    expect(page.url()).toContain('c=DwfgDgFmBQD0sAICmAPAhgWzAGyQgxgPYAmS0kYAlgHYBmhAFAJQDcQA')
-    expect(page.url()).toContain('v=8.3')
-    expect(page.url()).toContain('f=html')
+    const defaultPage = `${PAGE}/?c=DwfgDgFmBQD0sAICmAPAhgWzAGyQgxgPYAmS0kYAlgHYBmhAFAJQDcQA&v=8.3&f=html`
+    await page.waitForURL(defaultPage)
+    expect(page.url()).toContain(defaultPage)
   })
 
   test('switch preview', async ({ page }) => {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
   /* Retry on CI only */
   retries: 3,
   /* Opt out of parallel tests on CI. */
-  workers: 2,
+  workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
URL test is not safety